### PR TITLE
Ignore hidden files in .ssh

### DIFF
--- a/python/proof.py
+++ b/python/proof.py
@@ -91,6 +91,8 @@ Now the script needs your ssh key to generate proof. Please, enter path for gith
 def is_ssh_key(path):
     if not os.path.isfile(path):
         return False
+    if os.path.basename(path).startswith('.'):
+        return False
 
     with open(path, 'r') as file:
         key = file.read()


### PR DESCRIPTION
Prevent crashing on reading hidden binary files like .DS_Store on OSX.