### PR TITLE
readme: use network=none with docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@
 
 2. If your ssh keys are in ~/.ssh, run the script:
 
-   > `docker run -it --network none -v ~/.ssh:/root/.ssh dev-reward-script`
+   > `docker run -it --network none -v ~/.ssh:/root/.ssh:ro dev-reward-script`
 
    If your ssh keys are in other directories, replace
    {dir_path_for_your_ssh_keys} with your directory path:
 
-   > `docker run -it --network none -v /{dir_path_for_your_ssh_keys}:/root/.ssh dev-reward-script`
+   > `docker run -it --network none -v /{dir_path_for_your_ssh_keys}:/root/.ssh:ro dev-reward-script`
 
 # Generate proof (local sh script)
 

--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@
 
 2. If your ssh keys are in ~/.ssh, run the script:
 
-   > `docker run -it -v ~/.ssh:/root/.ssh dev-reward-script`
+   > `docker run -it --network none -v ~/.ssh:/root/.ssh dev-reward-script`
 
    If your ssh keys are in other directories, replace
    {dir_path_for_your_ssh_keys} with your directory path:
 
-   > `docker run -it -v /{dir_path_for_your_ssh_keys}:/root/.ssh dev-reward-script`
+   > `docker run -it --network none -v /{dir_path_for_your_ssh_keys}:/root/.ssh dev-reward-script`
 
 # Generate proof (local sh script)
 


### PR DESCRIPTION
It feels a bit safer to run the container without any networking capabilities.