### PR TITLE
fix(sshkey): Remove the line break of ssh pub key

### DIFF
--- a/python/proof.py
+++ b/python/proof.py
@@ -89,7 +89,7 @@ Now the script needs your ssh key to generate proof. Please, enter path for gith
     with open(pubKeyPath, 'r') as pubKeyFile:
         pubKey = " ".join(pubKeyFile.read().split(" ")[0:2])
 
-    return pubKey, sshKeyPath
+    return pubKey.strip(), sshKeyPath
 
 
 def is_ssh_key(path):


### PR DESCRIPTION
**Reprodition method:**
There is a line break`(\n)` at the end of the SSH public key, which will result in the following error.

```
Specified SSH key is not eligible for claiming. Only RSA and Ed25519 keys are supported for proof generation.
```


Use `print` to output the parameters in `decrypt_temp_eth_account`.
```diff
 def decrypt_temp_eth_account(sshPubKey, sshPrivKey, username, metadata):
+    print(sshPubKey, sshPrivKey, username, metadata.encryptedKeys[username])
     if sshPubKey not in metadata.encryptedKeys[username]:
         error("Specified SSH key is not eligible for claiming. Only RSA and Ed25519 keys are supported for proof generation.")
     data = metadata.encryptedKeys[username][sshPubKey]
     result = subprocess.run(["age",
                             "--decrypt",
                             "--identity",
                             sshPrivKey],
                            capture_output=True,
                            input=data.encode(),
                            env=env)
     if result.returncode != 0:
         raise OSError(result.stderr)
     return w3.eth.account.from_key(result.stdout.decode())
```

**Debugging screenshot:**

<img width="801" alt="image" src="https://github.com/fluencelabs/dev-rewards/assets/13550898/341026e8-3c6f-4f41-9a04-94d62940b33e">


<img width="837" alt="image" src="https://github.com/fluencelabs/dev-rewards/assets/13550898/fbc19471-6ea3-4ac2-b2f1-a100c2bf6d1c">
