### PR TITLE
Fix Error for Python

### DIFF
--- a/python/helpers/common.py
+++ b/python/helpers/common.py
@@ -1,10 +1,12 @@
 from dataclasses import dataclass
 from dataclasses_json import dataclass_json
+from typing import List, Dict
 
 
 @dataclass_json
 @dataclass
 class Metadata:
     root: str
-    addresses: list[str]
-    encryptedKeys: dict[str, dict[str, str]]
+    addresses: List[str]
+    encryptedKeys: Dict[str, Dict[str, str]]
+

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,3 +1,3 @@
-eth-account==0.11.0
+eth-account==0.10.0
 web3==6.15.1
 dataclasses-json==0.6.4


### PR DESCRIPTION
When running this program, there is an error as follows:

```
Traceback (most recent call last):
  File "python/proof.py", line 11, in <module>
    from helpers.common import Metadata
  File "/Users/wanglin/Downloads/dev-rewards-main/python/helpers/common.py", line 6, in <module>
    @dataclass
  File "/Users/wanglin/Downloads/dev-rewards-main/python/helpers/common.py", line 9, in Metadata
    addresses: list[str]
TypeError: 'type' object is not subscriptable

```

Also the dependencies for eth-account==0.11.0 is not available. 