### PR TITLE
add xxd to pre-flight check

### DIFF
--- a/proof-sh/proof.sh
+++ b/proof-sh/proof.sh
@@ -32,7 +32,7 @@ check_program_in_path() {
 
 # check that everything installed
 PATH="${PATH}:./bin"
-for i in age base64 sha3sum; do
+for i in age base64 sha3sum xxd; do
   check_program_in_path $i
 done
 


### PR DESCRIPTION
On my machine, `proof.sh` failed when it got to the first line which tried to run `xxd`, which I did not have installed.

This change fixed it.  Now it warns me if `xxd` is not installed..

FYI, on my machine `apt-get install xxd` installs the needed program.