### PR TITLE
add docker --read-only flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@
 
 2. If your ssh keys are in ~/.ssh, run the script:
 
-   > `docker run -it --rm --network none -v ~/.ssh:/root/.ssh:ro dev-reward-script`
+   > `docker run -it --rm --network none --read-only -v ~/.ssh:/root/.ssh:ro dev-reward-script`
 
    If your ssh keys are in other directories, replace
    {dir_path_for_your_ssh_keys} with your directory path:
 
-   > `docker run -it --rm --network none -v /{dir_path_for_your_ssh_keys}:/root/.ssh:ro dev-reward-script`
+   > `docker run -it --rm --network none --read-only -v /{dir_path_for_your_ssh_keys}:/root/.ssh:ro dev-reward-script`
 
 # Generate proof (local sh script)
 


### PR DESCRIPTION
adding docker `--read-only` flag to avoid keys being deleted in container by accident