### PR TITLE
give local .bin higher priority

### DIFF
--- a/proof-sh/proof.sh
+++ b/proof-sh/proof.sh
@@ -31,7 +31,7 @@ check_program_in_path() {
 # while true; do :; done
 
 # check that everything installed
-PATH="${PATH}:./bin"
+PATH="./bin:${PATH}"
 for i in age base64 sha3sum; do
   check_program_in_path $i
 done


### PR DESCRIPTION
There are other binaries available called sha3sum (e.g. as part of `busybox`).

As a result, those will be executed, and while they throw an error, that error will be swallowed because of the `sha3sum || true` call.

As a result, you get a completely wrong hash in the end end well, dig for the reason for quite a while.

This PR will prioritize the downloaded binary over any system binary.

Tbh., I would also recommend removing that `|| true` - it's bound to bring more problems than it solves.