### PR TITLE
Update MANUAL_INSTRUCTIONS.md

### DIFF
--- a/MANUAL_INSTRUCTIONS.md
+++ b/MANUAL_INSTRUCTIONS.md
@@ -14,7 +14,7 @@ The following can be done in a Docker container for additional isolation, includ
 6. Take one of the output lines, minus 'githubusername,' at the beginning, this is your encrypted blob in hex
 7. `echo <encrypted blob in hex> | xxd -r -p -c 1000 > enc.bin` to convert the hex to binary
 8.  If running in Docker, copy your private ssh key inside the docker (e.g. `docker cp path/to/local/private/key/file <container id>:/path/to/private/key/file`, or just use copy/paste in your terminal to a file)
-9.  `~/go/bin/age --decrypt --identity <path to private key file> --output dec.bin enc.bin` to decrypt the binary file
+9.  `age --decrypt --identity <path to private key file> --output dec.bin enc.bin` to decrypt the binary file
 10. The file `dec.bin` has one line with 4 comma-separated entries, extract each of them to a variable:
     - `USER_ID=$(cat dec.bin | cut -d, -f1)`
     - `ETH_ADDR=$(cat dec.bin | cut -d, -f2)`


### PR DESCRIPTION
Remove `go` reference. `go` used to be installed in the first version of the file. This is no longer the case and the command fails.