### PR TITLE
Enhance scam warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # Fluence Developer Rewards
 
-This repo allows the one to generate proof signature for Fluence dev reward claiming.
+This repo allows one to generate a proof signature for Fluence dev reward claiming.
 
-> Beware of scam emails, asking you to generate proofs for someone! See #98
+> [!CAUTION]
+> Beware of scam emails, asking you to generate proofs for someone! See [#98](https://github.com/fluencelabs/dev-rewards/pull/98).
 
 The methods for generating signature are described below:
 


### PR DESCRIPTION
I also received a scam email, as described in #98. In #99, a warning was added to the README. This PR enhances that warning in two ways.

1. Explicitly makes the part `#98` link to #98, because this does not happen automatically in READMEs, and some people may not know that `#98` is supposed to link to an issue.
2. Use [GitHub-flavoured Markdown alert](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts) to make the warning more visible.

I also fixed what I think was a typo in the first sentence.