### PR TITLE
fix(report): set report URL to fluence.chat

### DIFF
--- a/proof-sh/proof.sh
+++ b/proof-sh/proof.sh
@@ -117,7 +117,7 @@ fi
 
 printf "\n\tNOTE: your SSH key is used ONLY LOCALLY to decrypt a message and generate Token Claim Proof."
 printf "\n\tScript will explicitly ask your consent before using the key."
-printf "\n\tIf you have any technical issues, take a look at $OPENSSL_STDERR and $AGE_STDERR files and report to https://fluence.chat \n\n"
+printf "\n\tIf you have any technical issues, take a look at the following logs:\n\t\t$OPENSSL_STDERR\n\t\t$AGE_STDERR\n\treport to https://fluence.chat \n\n"
 
 printf "Now the script needs your ssh key to generate proof. \n"
 
@@ -156,7 +156,7 @@ while true; do
         ENCRYPTED_DATA=$(echo "$encrypted" | cut -d',' -f2)
 
         set +o errexit
-        echo "$ENCRYPTED_DATA" | xxd -r -p -c 1000 | age --decrypt --identity "$KEY_PATH" --output "$DECRYPTED_DATA" 2>$OPENSSL_STDERR
+        echo "$ENCRYPTED_DATA" | xxd -r -p -c 1000 | age --decrypt --identity "$KEY_PATH" --output "$DECRYPTED_DATA" 2>$AGE_STDERR
         exit_code=$?
         set -o errexit
 
@@ -175,8 +175,8 @@ while true; do
         echo "Possible causes are:"
         echo "You have specified the file which doesn't contain valid private key."
         echo "Your private key doesn't match your public key in GitHub. It could happen if you've changed local ssh key recently."
-        echo "Internal ape error:"
-        cat $OPENSSL_STDERR
+        echo "Internal error:"
+        cat $AGE_STDERR | sed -e 's#https://filippo.io/age/report#https://fluence.chat#g'
     fi
 done
 

--- a/proof-sh/proof.sh
+++ b/proof-sh/proof.sh
@@ -117,7 +117,7 @@ fi
 
 printf "\n\tNOTE: your SSH key is used ONLY LOCALLY to decrypt a message and generate Token Claim Proof."
 printf "\n\tScript will explicitly ask your consent before using the key."
-printf "\n\tIf you have any technical issues, take a look at the following logs:\n\t\t$OPENSSL_STDERR\n\t\t$AGE_STDERR\n\treport to https://fluence.chat \n\n"
+printf "\n\tIf you have any technical issues, take a look at the following logs:\n\t\t$OPENSSL_STDERR\n\t\t$AGE_STDERR\n\tReport any issues to https://fluence.chat \n\n"
 
 printf "Now the script needs your ssh key to generate proof. \n"
 
@@ -176,7 +176,12 @@ while true; do
         echo "You have specified the file which doesn't contain valid private key."
         echo "Your private key doesn't match your public key in GitHub. It could happen if you've changed local ssh key recently."
         echo "Internal error:"
-        cat $AGE_STDERR | sed -e 's#https://filippo.io/age/report#https://fluence.chat#g'
+        # replace report URL in $AGE_STDERR
+
+        STDERR_TMP="$(mktemp)"
+        cat "$AGE_STDERR" | sed -e 's#https://filippo.io/age/report#https://fluence.chat#g' > $STDERR_TMP
+        cat "$STDERR_TMP" > "$AGE_STDERR"
+        cat "$AGE_STDERR"
     fi
 done
 

--- a/proof-sh/proof.sh
+++ b/proof-sh/proof.sh
@@ -179,7 +179,7 @@ while true; do
 
         # replace report URL in $AGE_STDERR
         STDERR_TMP="$(mktemp)"
-        cat "$AGE_STDERR" | sed -e 's#https://filippo.io/age/report#https://fluence.chat#g' > $STDERR_TMP
+        cat "$AGE_STDERR" | sed -e 's#https://filippo.io/age/report#https://fluence.chat#g' > "$STDERR_TMP"
         cat "$STDERR_TMP" > "$AGE_STDERR"
 
         # print Age error with replaced report URL

--- a/proof-sh/proof.sh
+++ b/proof-sh/proof.sh
@@ -176,11 +176,13 @@ while true; do
         echo "You have specified the file which doesn't contain valid private key."
         echo "Your private key doesn't match your public key in GitHub. It could happen if you've changed local ssh key recently."
         echo "Internal error:"
-        # replace report URL in $AGE_STDERR
 
+        # replace report URL in $AGE_STDERR
         STDERR_TMP="$(mktemp)"
         cat "$AGE_STDERR" | sed -e 's#https://filippo.io/age/report#https://fluence.chat#g' > $STDERR_TMP
         cat "$STDERR_TMP" > "$AGE_STDERR"
+
+        # print Age error with replaced report URL
         cat "$AGE_STDERR"
     fi
 done

--- a/python/proof.py
+++ b/python/proof.py
@@ -118,7 +118,8 @@ def decrypt_temp_eth_account(sshPubKey, sshPrivKey, username, metadata):
                             input=data.encode(),
                             env=env)
     if result.returncode != 0:
-        raise OSError(result.stderr)
+        age_stderr = result.stderr.replace('https://filippo.io/age/report', 'https://fluence.chat')
+        raise OSError(age_stderr)
 
     return w3.eth.account.from_key(result.stdout.decode())
 


### PR DESCRIPTION
- Replaced AGE report url with fluence.chat in proof.sh and proof.py
- Use correct variable for AGE's stderr in proof.sh

Output from proof.sh now looks like this:
```
Internal error:
age: error: reading "/Users/folex/.ssh/id_ecdsa": malformed SSH identity in "/Users/folex/.ssh/id_ecdsa": unsupported SSH identity type: *ecdsa.PrivateKey
age: report unexpected or unhelpful errors at https://fluence.chat
```
