### PR TITLE
add download metadata.json file before run script

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,11 @@ The methods for generating signature are described below:
 
    > https://www.python.org/downloads/
 
-2. Install dependencies
+2. Download the metadata.json file
+
+    > curl https://fluence-dao.s3.eu-west-1.amazonaws.com/metadata.json > metadata.json
+
+3. Install dependencies
 
    > `./install.sh`
 
@@ -48,7 +52,7 @@ The methods for generating signature are described below:
 
    > `pip3 install -r python/requirements.txt`
 
-3. Run the script
+4. Run the script
 
    > `python3 python/proof.py`
 

--- a/python/proof.py
+++ b/python/proof.py
@@ -136,6 +136,10 @@ def get_merkle_proof(metadata, tempETHAccount):
 
 def main():
     metadataPath = "metadata.json"
+    if not os.pathh.exists(metadataPath):
+        os.system(
+            "curl https://fluence-dao.s3.eu-west-1.amazonaws.com/metadata.json > metadata.json"
+        )
     metadata = parse_metadata(metadataPath)
 
     print('''


### PR DESCRIPTION
Fix error of not finding metadata.json file when running script locally.

![image](https://github.com/fluencelabs/dev-rewards/assets/32336879/492fc893-efac-438c-96b0-3f1d2406f7f5)
